### PR TITLE
Fix "health report" spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Currently we support only `buildstatus` set to true
 It returns a map like this
 
 ```
-{:lastCompletedBuild "https://jenkins.com/job/my-job-magic/175/", :healtReport "Build stability: All recent builds failed.", :lastFailedBuild "https://ci.jenkins.com/job/my-job-magic/175/", :lastStableBuild "https://ci.jenkins.com/job/my-job-magic/152/"} 
+{:lastCompletedBuild "https://jenkins.com/job/my-job-magic/175/", :healthReport "Build stability: All recent builds failed.", :lastFailedBuild "https://ci.jenkins.com/job/my-job-magic/175/", :lastStableBuild "https://ci.jenkins.com/job/my-job-magic/152/"}
 ```
 
 This map/data will then sent via notificationschannel

--- a/src/saint_build/core.clj
+++ b/src/saint_build/core.clj
@@ -28,7 +28,7 @@
   (if (:error data) (log/error "data was corrupted skipping")
   ;; if data ok select it
   (assoc {} :lastCompletedBuild (:url (:lastCompletedBuild data))
-       :healtReport     (:description (first (:healthReport data)))
+       :healthReport    (:description (first (:healthReport data)))
        :lastFailedBuild (:url (:lastFailedBuild data)) 
        :lastStableBuild (:url (:lastStableBuild data)))))
 


### PR DESCRIPTION
Minor spelling fix in the associative array key for "health report". :)